### PR TITLE
add variable for service state

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,5 @@
 awslogs_install_dir: "/var/awslogs/install"
 awslogs_install_url: "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py"
 awslogs_enforce_latest: false
+awslogs_service_state: started
 aws_region: "eu-west-1"

--- a/tasks/install_centos_6.yml
+++ b/tasks/install_centos_6.yml
@@ -74,7 +74,7 @@
 - name: Start awslogs service
   service:
     name: awslogs
-    state: started
+    state: "{{ awslogs_service_state }}"
 
 # service module does not enable when systemd and init are installed.
 # Need the "use:" directive as workaround

--- a/tasks/install_centos_7.yml
+++ b/tasks/install_centos_7.yml
@@ -87,7 +87,7 @@
 - name: Start awslogs service
   service:
     name: awslogs
-    state: started
+    state: "{{ awslogs_service_state }}"
 
 # service module does not enable when systemd and init are installed.
 # Need the "use:" directive as workaround


### PR DESCRIPTION
Add `awslogs_service_state` (default `started`) -- useful since the awslogs service's default is to consume `/var/log/messages`, and it cannot easily be set to consume nothing.